### PR TITLE
Set custom User-Agent on feedparser to avoid Reddit blocks

### DIFF
--- a/bot/app/commands/news/news.py
+++ b/bot/app/commands/news/news.py
@@ -24,6 +24,8 @@ from bot.app.story_history import (
 
 logger = logging.getLogger("NewsCommands")
 
+FEED_USER_AGENT = "Mozilla/5.0 (compatible; CunningBot/1.0; +https://github.com/cunningjams/cunningbot)"
+
 
 def _is_valid_url(url: str) -> bool:
     """Simple URL validation."""
@@ -206,7 +208,7 @@ class NewsCog(commands.Cog):
             # Fetch feed with timeout protection
             try:
                 feed = await asyncio.wait_for(
-                    asyncio.to_thread(feedparser.parse, feed_url),
+                    asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
                     timeout=30.0
                 )
             except asyncio.TimeoutError:
@@ -1124,7 +1126,7 @@ class NewsCog(commands.Cog):
             # Fetch the feed with timeout protection
             try:
                 feed = await asyncio.wait_for(
-                    asyncio.to_thread(feedparser.parse, feed_url),
+                    asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
                     timeout=30.0
                 )
             except asyncio.TimeoutError:

--- a/bot/app/tasks/rss_feed_poster.py
+++ b/bot/app/tasks/rss_feed_poster.py
@@ -26,6 +26,8 @@ import discord
 import feedparser
 from dotenv import load_dotenv
 
+FEED_USER_AGENT = "Mozilla/5.0 (compatible; CunningBot/1.0; +https://github.com/cunningjams/cunningbot)"
+
 # Load environment variables from .env
 load_dotenv()
 from bot.app.redis.rss_store import RSSRedisStore
@@ -425,7 +427,7 @@ async def collect_rss_updates() -> None:
                     # feedparser.parse() is synchronous and can hang, so run in thread with timeout
                     try:
                         feed = await asyncio.wait_for(
-                            asyncio.to_thread(feedparser.parse, feed_url),
+                            asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
                             timeout=30.0  # 30 second timeout per feed
                         )
                     except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- Reddit was returning an HTML block page to feedparser's default User-Agent, causing `/news add` (and background polling) to fail with `not well-formed (invalid token)` on Reddit RSS feeds.
- Pass a browser-style `FEED_USER_AGENT` to all three `feedparser.parse` call sites (news add, news check, rss_feed_poster).

## Test plan
- [ ] `/news add` a Reddit RSS URL (e.g. `https://www.reddit.com/r/sandiegan/.rss`) and confirm it parses
- [ ] Confirm existing non-Reddit feeds still poll normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)