### PR TITLE
Fetch RSS feeds with aiohttp to sidestep Reddit 403s

### DIFF
--- a/bot/app/commands/news/news.py
+++ b/bot/app/commands/news/news.py
@@ -4,7 +4,6 @@ from discord import app_commands
 from discord.ext import commands
 from typing import Any, Optional
 from urllib.parse import urlparse
-import feedparser
 from datetime import datetime
 from html.parser import HTMLParser
 import logging
@@ -22,9 +21,9 @@ from bot.app.story_history import (
     DEFAULT_DEDUP_WINDOW_HOURS
 )
 
-logger = logging.getLogger("NewsCommands")
+from bot.app.utils.feed_fetch import fetch_and_parse_feed
 
-FEED_USER_AGENT = "Mozilla/5.0 (compatible; CunningBot/1.0; +https://github.com/cunningjams/cunningbot)"
+logger = logging.getLogger("NewsCommands")
 
 
 def _is_valid_url(url: str) -> bool:
@@ -208,7 +207,7 @@ class NewsCog(commands.Cog):
             # Fetch feed with timeout protection
             try:
                 feed = await asyncio.wait_for(
-                    asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
+                    fetch_and_parse_feed(feed_url),
                     timeout=30.0
                 )
             except asyncio.TimeoutError:
@@ -1126,7 +1125,7 @@ class NewsCog(commands.Cog):
             # Fetch the feed with timeout protection
             try:
                 feed = await asyncio.wait_for(
-                    asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
+                    fetch_and_parse_feed(feed_url),
                     timeout=30.0
                 )
             except asyncio.TimeoutError:

--- a/bot/app/tasks/rss_feed_poster.py
+++ b/bot/app/tasks/rss_feed_poster.py
@@ -23,10 +23,9 @@ from html.parser import HTMLParser
 
 import aiohttp
 import discord
-import feedparser
 from dotenv import load_dotenv
 
-FEED_USER_AGENT = "Mozilla/5.0 (compatible; CunningBot/1.0; +https://github.com/cunningjams/cunningbot)"
+from bot.app.utils.feed_fetch import fetch_and_parse_feed
 
 # Load environment variables from .env
 load_dotenv()
@@ -424,10 +423,9 @@ async def collect_rss_updates() -> None:
                     logger.info("Fetching feed '%s' from %s", feed_name, feed_url)
 
                     # Fetch and parse the feed with timeout protection
-                    # feedparser.parse() is synchronous and can hang, so run in thread with timeout
                     try:
                         feed = await asyncio.wait_for(
-                            asyncio.to_thread(feedparser.parse, feed_url, agent=FEED_USER_AGENT),
+                            fetch_and_parse_feed(feed_url),
                             timeout=30.0  # 30 second timeout per feed
                         )
                     except asyncio.TimeoutError:

--- a/bot/app/utils/feed_fetch.py
+++ b/bot/app/utils/feed_fetch.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import aiohttp
+import feedparser
+
+FEED_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+FEED_FETCH_HEADERS = {
+    "User-Agent": FEED_USER_AGENT,
+    "Accept": "application/atom+xml, application/rss+xml, application/xml;q=0.9, text/xml;q=0.8, */*;q=0.5",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+async def fetch_and_parse_feed(feed_url: str, timeout: float = 30.0) -> feedparser.FeedParserDict:
+    """Fetch a feed via aiohttp and parse the bytes with feedparser.
+
+    Feedparser's built-in HTTP client sends headers (notably ``A-IM: feed``)
+    that Reddit and some other hosts block with a 403. Fetching the bytes
+    ourselves with a browser-style User-Agent avoids the block.
+    """
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
+    async with aiohttp.ClientSession(headers=FEED_FETCH_HEADERS, timeout=client_timeout) as session:
+        async with session.get(feed_url) as response:
+            response.raise_for_status()
+            body = await response.read()
+    return await asyncio.to_thread(feedparser.parse, body)


### PR DESCRIPTION
## Summary
- The previous User-Agent-only fix (PR #19) wasn't enough — Reddit now returns 403 to feedparser's built-in HTTP client regardless of UA, because feedparser sends an `A-IM: feed` header that Reddit fingerprints as a bot.
- Verified by reproducing from inside the container: feedparser → 403; curl with the same UA → 200; aiohttp with browser headers → 200 + 25 entries parsed.
- New helper `bot/app/utils/feed_fetch.py::fetch_and_parse_feed` fetches bytes via `aiohttp` with a Chrome UA + standard Accept headers, then passes the bytes to `feedparser.parse` (which is happy to parse in-memory bytes).
- All three call sites now use the helper: `/news add`, the news-check command, and the background `rss_feed_poster` task. Dropped the now-unused `feedparser` import from those files.

## Test plan
- [ ] Run `/news add` with `https://www.reddit.com/r/sandiegan/.rss` and confirm it parses
- [ ] Confirm existing non-Reddit feeds (including FreshRSS) still fetch cleanly in the background poller
- [ ] Confirm the polling loop on the Pi logs entries > 0 for Reddit feeds after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)