### PR TITLE
Add CometCave migration notice to daily trivia posts

### DIFF
--- a/bot/app/tasks/trivia_game_poster.py
+++ b/bot/app/tasks/trivia_game_poster.py
@@ -139,6 +139,16 @@ def create_batch_overview_embed(
     )
 
     embed.add_field(
+        name="⚠️ Heads up — /trivia is moving!",
+        value=(
+            "This Discord trivia bot will be **shutting down soon**.\n"
+            "Play the new daily trivia at **https://cometcave.com/trivia** "
+            "— shareable scores, global leaderboard, same daily cadence."
+        ),
+        inline=False
+    )
+
+    embed.add_field(
         name="📝 How to Answer",
         value=(
             "Click the **A / B / C / D** buttons on each question below.\n\n"


### PR DESCRIPTION
## Summary
Adds a prominent warning field at the top of the daily trivia overview embed, directing users to the new webapp and noting the Discord `/trivia` feature will shut down soon.

## Appears as
```
⚠️ Heads up — /trivia is moving!
This Discord trivia bot will be shutting down soon.
Play the new daily trivia at https://cometcave.com/trivia —
shareable scores, global leaderboard, same daily cadence.
```

Shown on both:
- OpenTDB method overview embeds
- AI-only method overview embeds

(Both paths use `create_batch_overview_embed`)

## Test plan
- [ ] Trigger a manual `/trivia post` and verify the warning field appears first
- [ ] Verify the link is clickable in Discord
- [ ] Verify wording is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)