### PR TITLE
Add /lunchboyz delay, previous, and sub commands

### DIFF
--- a/bot/app/commands/lunchboyz/lunchboyz.py
+++ b/bot/app/commands/lunchboyz/lunchboyz.py
@@ -1,7 +1,8 @@
 """Lunch Boyz rotation command cog for CunningBot.
 
-Provides /lunchboyz setup, status, skip, plan, and advance commands
-for managing a bi-weekly rotating lunch/happy-hour responsibility.
+Provides /lunchboyz setup, status, skip, plan, advance, delay, previous,
+and sub commands for managing a bi-weekly rotating lunch/happy-hour
+responsibility.
 """
 
 import datetime
@@ -192,9 +193,19 @@ class LunchboyzCog(commands.Cog):
         deadline = make_deadline(last_advanced, frequency_days)
 
         embed = discord.Embed(title="🍽️ Lunch Boyz Status", color=0xF4A460)
+
+        substitute = state.get("substitute")
+        if substitute:
+            sub_id = substitute["user_id"]
+            sub_name = get_member_name(interaction.guild, sub_id)
+            orig_name = get_member_name(interaction.guild, substitute["original_user_id"])
+            currently_up_value = f"<@{sub_id}> ({sub_name}) (subbing for {orig_name})"
+        else:
+            currently_up_value = f"<@{current_id}> ({current_name})"
+
         embed.add_field(
             name="Currently Up",
-            value=f"<@{current_id}> ({current_name})",
+            value=currently_up_value,
             inline=False,
         )
 
@@ -261,6 +272,7 @@ class LunchboyzCog(commands.Cog):
         state["last_advanced"] = datetime.date.today().isoformat()
         state["event"] = None
         state["reminders_sent"] = []
+        state["substitute"] = None
         await store.save_state(guild_id_str, state)
 
         next_id = rotation[new_idx]
@@ -386,6 +398,7 @@ class LunchboyzCog(commands.Cog):
         state["last_advanced"] = datetime.date.today().isoformat()
         state["event"] = None
         state["reminders_sent"] = []
+        state["substitute"] = None
         await store.save_state(guild_id_str, state)
 
         next_id = rotation[new_idx]
@@ -405,6 +418,161 @@ class LunchboyzCog(commands.Cog):
             await channel.send(embed=embed)
 
         await interaction.followup.send("Rotation advanced.", ephemeral=True)
+
+    # ------------------------------------------------------------------
+    # /lunchboyz delay
+    # ------------------------------------------------------------------
+
+    @lunchboyz.command(
+        name="delay",
+        description="Delay the current rotation by 1 week.",
+    )
+    async def delay(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        guild_id_str = guild_id_to_str(interaction.guild_id)
+        store = LunchboyzRedisStore()
+        config = await store.get_config(guild_id_str)
+        rotation = await store.get_rotation(guild_id_str)
+        state = await store.get_state(guild_id_str)
+
+        if not config or not rotation or not state:
+            await interaction.followup.send(
+                "Lunch Boyz hasn't been set up yet. Use `/lunchboyz setup` first.",
+                ephemeral=True,
+            )
+            return
+
+        new_last_advanced = (
+            datetime.date.fromisoformat(state["last_advanced"]) + datetime.timedelta(days=7)
+        ).isoformat()
+        state["last_advanced"] = new_last_advanced
+        state["event"] = None
+        state["reminders_sent"] = []
+        # substitute is intentionally preserved
+        await store.save_state(guild_id_str, state)
+
+        frequency_days = config.get("frequency_days", 14)
+        new_deadline = make_deadline(new_last_advanced, frequency_days)
+
+        current_idx = state.get("current_index", 0) % len(rotation)
+        current_id = rotation[current_idx]
+
+        substitute = state.get("substitute")
+        if substitute:
+            display_id = substitute["user_id"]
+        else:
+            display_id = current_id
+        display_name = get_member_name(interaction.guild, display_id)
+
+        channel_id = int(config["channel_id"])
+        channel = self.bot.get_channel(channel_id)
+        if channel and isinstance(channel, discord.TextChannel):
+            await channel.send(
+                f"⏳ Event delayed by 1 week. <@{display_id}> ({display_name}) is still up — "
+                f"new deadline: {new_deadline.strftime('%m/%d/%Y')}."
+            )
+
+        await interaction.followup.send("Rotation delayed by 1 week.", ephemeral=True)
+
+    # ------------------------------------------------------------------
+    # /lunchboyz previous
+    # ------------------------------------------------------------------
+
+    @lunchboyz.command(
+        name="previous",
+        description="Rotate back to the previous person.",
+    )
+    async def previous(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        guild_id_str = guild_id_to_str(interaction.guild_id)
+        store = LunchboyzRedisStore()
+        config = await store.get_config(guild_id_str)
+        rotation = await store.get_rotation(guild_id_str)
+        state = await store.get_state(guild_id_str)
+
+        if not config or not rotation or not state:
+            await interaction.followup.send(
+                "Lunch Boyz hasn't been set up yet. Use `/lunchboyz setup` first.",
+                ephemeral=True,
+            )
+            return
+
+        current_idx = state.get("current_index", 0)
+        new_idx = (current_idx - 1) % len(rotation)
+        state["current_index"] = new_idx
+        state["last_advanced"] = datetime.date.today().isoformat()
+        state["event"] = None
+        state["reminders_sent"] = []
+        state["substitute"] = None
+        await store.save_state(guild_id_str, state)
+
+        frequency_days = config.get("frequency_days", 14)
+        new_deadline = make_deadline(state["last_advanced"], frequency_days)
+
+        prev_id = rotation[new_idx]
+        prev_name = get_member_name(interaction.guild, prev_id)
+
+        channel_id = int(config["channel_id"])
+        channel = self.bot.get_channel(channel_id)
+        if channel and isinstance(channel, discord.TextChannel):
+            await channel.send(
+                f"⏮️ Rotated back. <@{prev_id}> ({prev_name}) is now up! "
+                f"Deadline: {new_deadline.strftime('%m/%d/%Y')}."
+            )
+
+        await interaction.followup.send("Rotated back to previous person.", ephemeral=True)
+
+    # ------------------------------------------------------------------
+    # /lunchboyz sub
+    # ------------------------------------------------------------------
+
+    @lunchboyz.command(
+        name="sub",
+        description="Set a substitute for the current rotation slot.",
+    )
+    @app_commands.describe(user="The member who will sub in this round.")
+    async def sub(self, interaction: discord.Interaction, user: discord.Member) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        guild_id_str = guild_id_to_str(interaction.guild_id)
+        store = LunchboyzRedisStore()
+        config = await store.get_config(guild_id_str)
+        rotation = await store.get_rotation(guild_id_str)
+        state = await store.get_state(guild_id_str)
+
+        if not config or not rotation or not state:
+            await interaction.followup.send(
+                "Lunch Boyz hasn't been set up yet. Use `/lunchboyz setup` first.",
+                ephemeral=True,
+            )
+            return
+
+        current_idx = state.get("current_index", 0) % len(rotation)
+        current_id = rotation[current_idx]
+
+        if str(user.id) == current_id:
+            await interaction.followup.send("They're already up!", ephemeral=True)
+            return
+
+        state["substitute"] = {
+            "user_id": str(user.id),
+            "original_user_id": current_id,
+        }
+        await store.save_state(guild_id_str, state)
+
+        original_name = get_member_name(interaction.guild, current_id)
+
+        channel_id = int(config["channel_id"])
+        channel = self.bot.get_channel(channel_id)
+        if channel and isinstance(channel, discord.TextChannel):
+            await channel.send(
+                f"🔁 <@{user.id}> ({user.display_name}) is subbing in for "
+                f"{original_name} this round!"
+            )
+
+        await interaction.followup.send("Substitute set.", ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/bot/app/tasks/lunchboyz_reminder.py
+++ b/bot/app/tasks/lunchboyz_reminder.py
@@ -70,6 +70,8 @@ async def process_guild(
     today = today_in_tz(timezone)
     current_idx = state.get("current_index", 0) % len(rotation)
     current_user_id = rotation[current_idx]
+    substitute = state.get("substitute") or {}
+    reminder_user_id = substitute.get("user_id", current_user_id)
     reminders_sent = state.get("reminders_sent", [])
 
     event = state.get("event")
@@ -139,6 +141,7 @@ async def process_guild(
                 fresh_state["last_advanced"] = fresh_today.isoformat()
                 fresh_state["event"] = None
                 fresh_state["reminders_sent"] = []
+                fresh_state["substitute"] = None
                 await store.save_state(guild_id, fresh_state)
 
                 embed = discord.Embed(
@@ -174,12 +177,12 @@ async def process_guild(
         if days_until <= 7 and "7d" not in reminders_sent:
             if event:
                 msg = (
-                    f"📣 <@{current_user_id}>, Lunch Boyz is in {days_until} day(s)!\n"
+                    f"📣 <@{reminder_user_id}>, Lunch Boyz is in {days_until} day(s)!\n"
                     f"{event_details_str()}"
                 )
             else:
                 msg = (
-                    f"📣 <@{current_user_id}>, you're up for Lunch Boyz in {days_until} day(s)! "
+                    f"📣 <@{reminder_user_id}>, you're up for Lunch Boyz in {days_until} day(s)! "
                     f"You have until {target_date.strftime('%m/%d/%Y')}. "
                     "Don't forget to use `/lunchboyz plan` to let the crew know where we're going."
                 )
@@ -187,7 +190,7 @@ async def process_guild(
                 await channel.send(msg)
                 reminders_sent.append("7d")
                 needs_save = True
-                logger.info(f"Guild {guild_id}: sent 7d reminder to user {current_user_id}")
+                logger.info(f"Guild {guild_id}: sent 7d reminder to user {reminder_user_id}")
             except Exception as exc:
                 logger.error(f"Guild {guild_id}: failed to send 7d reminder: {exc}")
 
@@ -195,18 +198,18 @@ async def process_guild(
             urgency = "TODAY" if days_until <= 0 else "TOMORROW"
             if event:
                 msg = (
-                    f"🚨 <@{current_user_id}> — Lunch Boyz is {urgency}!\n"
+                    f"🚨 <@{reminder_user_id}> — Lunch Boyz is {urgency}!\n"
                     f"{event_details_str()}"
                 )
             else:
                 msg = (
-                    f"🚨 <@{current_user_id}> — Lunch Boyz is {urgency}! Have you set your event yet?"
+                    f"🚨 <@{reminder_user_id}> — Lunch Boyz is {urgency}! Have you set your event yet?"
                 )
             try:
                 await channel.send(msg)
                 reminders_sent.append("1d")
                 needs_save = True
-                logger.info(f"Guild {guild_id}: sent 1d reminder to user {current_user_id}")
+                logger.info(f"Guild {guild_id}: sent 1d reminder to user {reminder_user_id}")
             except Exception as exc:
                 logger.error(f"Guild {guild_id}: failed to send 1d reminder: {exc}")
 


### PR DESCRIPTION
## Summary
- **`/lunchboyz delay`** (#22): Pushes the rotation deadline back by 1 week without advancing. Stacks on repeated use. Preserves any active substitute.
- **`/lunchboyz previous`** (#23): Rotates backwards by 1, re-assigning the previous person with a fresh cycle.
- **`/lunchboyz sub @user`** (#24): Temporarily substitutes another user for the current turn without modifying the rotation order. Substitute is shown in status, receives reminders, and is cleared on rotation advance.

Also updates the `status` command to display substitutes, clears substitute on `skip`/`advance`/auto-advance, and routes reminders to the substitute when set.

Closes #22, closes #23, closes #24

## Test plan
- [ ] `/lunchboyz delay` adds 7 days to deadline, clears event/reminders, preserves sub
- [ ] Delay stacks (two delays = 14 days)
- [ ] `/lunchboyz previous` decrements index with wraparound, resets cycle
- [ ] `/lunchboyz sub @user` sets substitute, shows in status, errors if already current
- [ ] `skip`/`advance` clear substitute
- [ ] Reminder task pings substitute instead of original when set
- [ ] Auto-advance clears substitute

🤖 Generated with [Claude Code](https://claude.com/claude-code)