### PR TITLE
feat: News Roundup system for collecting matching articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .venv
 .venv310
 .env
+.claude-scratch/
 logs
 bot/core/app_state.json
 bot/app/app_state.json

--- a/bot/app/commands/news/news.py
+++ b/bot/app/commands/news/news.py
@@ -1,4 +1,5 @@
 import asyncio
+import re as _re
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -24,6 +25,15 @@ from bot.app.story_history import (
 from bot.app.utils.feed_fetch import fetch_and_parse_feed
 
 logger = logging.getLogger("NewsCommands")
+
+
+def _normalize_roundup_name(name: str) -> str:
+    """Normalize a roundup name for use as a Redis key component."""
+    slug = name.lower().strip()
+    slug = slug.replace(" ", "-")
+    slug = _re.sub(r"[^a-z0-9\-]", "", slug)
+    slug = _re.sub(r"-+", "-", slug).strip("-")
+    return slug[:50]
 
 
 def _is_valid_url(url: str) -> bool:
@@ -169,6 +179,12 @@ class NewsCog(commands.Cog):
 
     news = app_commands.Group(
         name="news", description="Manage RSS news feed subscriptions."
+    )
+
+    roundup = app_commands.Group(
+        name="roundup",
+        description="Manage news roundups that collect matching articles.",
+        parent=news,
     )
 
     @news.command(name="add", description="Add a new RSS feed to monitor in this channel.")
@@ -1580,6 +1596,183 @@ class NewsCog(commands.Cog):
         embed.set_footer(text="To disable: /news breaking topics:disable")
 
         await interaction.response.send_message(embed=embed)
+
+    # --- Roundup commands ---
+
+    @roundup.command(name="add", description="Create a new roundup that collects articles matching a query.")
+    @app_commands.describe(
+        name="Human-readable name for the roundup (e.g., 'New Releases')",
+        match_query="Search phrase to match articles against (e.g., 'new music releases')",
+    )
+    @app_commands.checks.has_permissions(administrator=True)
+    async def roundup_add(self, interaction: discord.Interaction, name: str, match_query: str) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message("This command can only be used in a text channel.", ephemeral=True)
+            return
+
+        slug = _normalize_roundup_name(name)
+        if not slug:
+            await interaction.response.send_message("Invalid roundup name. Use letters, numbers, and spaces.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        store = RSSRedisStore()
+        guild_id = guild_id_to_str(interaction.guild_id)
+        channel_id = str(channel.id)
+
+        existing = await store.get_roundup_config(guild_id, channel_id, slug)
+        if existing:
+            await interaction.followup.send(f"A roundup named **{name}** already exists in this channel.", ephemeral=True)
+            return
+
+        config = {
+            "name": name,
+            "name_normalized": slug,
+            "match_query": match_query,
+            "channel_id": channel_id,
+            "guild_id": guild_id,
+            "created_at": datetime.utcnow().isoformat() + "Z",
+        }
+        await store.save_roundup_config(guild_id, channel_id, slug, config)
+        await interaction.followup.send(f"Roundup **{name}** created! Matching articles for: `{match_query}`", ephemeral=True)
+
+    @roundup.command(name="list", description="Show all roundups configured for this channel.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def roundup_list(self, interaction: discord.Interaction) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message("This command can only be used in a text channel.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        store = RSSRedisStore()
+        guild_id = guild_id_to_str(interaction.guild_id)
+        channel_id = str(channel.id)
+
+        roundups = await store.list_roundups(guild_id, channel_id)
+        if not roundups:
+            await interaction.followup.send("No roundups configured for this channel.", ephemeral=True)
+            return
+
+        lines = []
+        for r in roundups:
+            count = r.get("article_count", 0)
+            lines.append(f"**{r['name']}** — query: `{r['match_query']}` — {count} article{'s' if count != 1 else ''}")
+
+        embed = discord.Embed(
+            title="News Roundups",
+            description="\n".join(lines),
+            color=discord.Color.blue(),
+        )
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @roundup.command(name="show", description="Show collected articles for a roundup.")
+    @app_commands.describe(
+        name="Roundup name (defaults to first roundup if omitted)",
+        page="Page number (default: 1)",
+    )
+    async def roundup_show(self, interaction: discord.Interaction, name: Optional[str] = None, page: int = 1) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message("This command can only be used in a text channel.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        store = RSSRedisStore()
+        guild_id = guild_id_to_str(interaction.guild_id)
+        channel_id = str(channel.id)
+
+        if name:
+            slug = _normalize_roundup_name(name)
+            config = await store.get_roundup_config(guild_id, channel_id, slug)
+            if not config:
+                await interaction.followup.send(f"No roundup named **{name}** found in this channel.", ephemeral=True)
+                return
+        else:
+            roundups = await store.list_roundups(guild_id, channel_id)
+            if not roundups:
+                await interaction.followup.send("No roundups configured for this channel.", ephemeral=True)
+                return
+            config = roundups[0]
+            slug = config["name_normalized"]
+
+        if page < 1:
+            page = 1
+
+        articles, total = await store.get_roundup_articles(guild_id, channel_id, slug, page=page)
+
+        if total == 0:
+            await interaction.followup.send(f"No articles collected yet for **{config['name']}**.", ephemeral=True)
+            return
+
+        total_pages = (total + 19) // 20  # ceil division
+        if page > total_pages:
+            await interaction.followup.send(f"Page {page} doesn't exist. There {'is' if total_pages == 1 else 'are'} only {total_pages} page{'s' if total_pages != 1 else ''}.", ephemeral=True)
+            return
+
+        lines = []
+        for article in articles:
+            title = article.get("title", "Untitled")
+            url = article.get("url", "")
+            if url:
+                lines.append(f"\u2022 [{title}]({url})")
+            else:
+                lines.append(f"\u2022 {title}")
+
+        embed = discord.Embed(
+            title=f"Roundup: {config['name']}",
+            description="\n".join(lines),
+            color=discord.Color.green(),
+        )
+        embed.set_footer(text=f"Page {page}/{total_pages} \u2022 {total} articles")
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @roundup.command(name="clear", description="Clear all collected articles from a roundup.")
+    @app_commands.describe(name="Name of the roundup to clear")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def roundup_clear(self, interaction: discord.Interaction, name: str) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message("This command can only be used in a text channel.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        store = RSSRedisStore()
+        guild_id = guild_id_to_str(interaction.guild_id)
+        channel_id = str(channel.id)
+        slug = _normalize_roundup_name(name)
+
+        config = await store.get_roundup_config(guild_id, channel_id, slug)
+        if not config:
+            await interaction.followup.send(f"No roundup named **{name}** found in this channel.", ephemeral=True)
+            return
+
+        count = await store.clear_roundup_articles(guild_id, channel_id, slug)
+        await interaction.followup.send(f"Cleared {count} article{'s' if count != 1 else ''} from **{config['name']}**.", ephemeral=True)
+
+    @roundup.command(name="delete", description="Delete a roundup and all its collected articles.")
+    @app_commands.describe(name="Name of the roundup to delete")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def roundup_delete(self, interaction: discord.Interaction, name: str) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message("This command can only be used in a text channel.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        store = RSSRedisStore()
+        guild_id = guild_id_to_str(interaction.guild_id)
+        channel_id = str(channel.id)
+        slug = _normalize_roundup_name(name)
+
+        config = await store.get_roundup_config(guild_id, channel_id, slug)
+        if not config:
+            await interaction.followup.send(f"No roundup named **{name}** found in this channel.", ephemeral=True)
+            return
+
+        count = await store.delete_roundup(guild_id, channel_id, slug)
+        await interaction.followup.send(f"Deleted roundup **{config['name']}** and {count} collected article{'s' if count != 1 else ''}.", ephemeral=True)
 
 
 def _format_article_list(articles: list[dict[str, Any]], start_number: int = 1) -> str:

--- a/bot/app/redis/rss_store.py
+++ b/bot/app/redis/rss_store.py
@@ -692,3 +692,108 @@ class RSSRedisStore:
                 break
 
         return guilds
+
+    # --- Roundup ---
+
+    async def get_roundup_config(self, guild_id: str, channel_id: str, name_normalized: str) -> Optional[Dict[str, Any]]:
+        """Get a roundup config."""
+        key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:config"
+        data = await self.redis.get(key)
+        if data:
+            return json.loads(data)
+        return None
+
+    async def save_roundup_config(self, guild_id: str, channel_id: str, name_normalized: str, config: Dict[str, Any]) -> None:
+        """Save roundup config and add to channel index."""
+        config_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:config"
+        index_key = f"news:{guild_id}:{channel_id}:roundup:_index"
+        await self.redis.set(config_key, json.dumps(config))
+        await self.redis.sadd(index_key, name_normalized)
+
+    async def delete_roundup(self, guild_id: str, channel_id: str, name_normalized: str) -> int:
+        """Delete a roundup entirely. Returns number of articles that were stored."""
+        articles_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:articles"
+        config_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:config"
+        index_key = f"news:{guild_id}:{channel_id}:roundup:_index"
+        count = await self.redis.llen(articles_key)
+        await self.redis.delete(config_key, articles_key)
+        await self.redis.srem(index_key, name_normalized)
+        return count
+
+    async def list_roundups(self, guild_id: str, channel_id: str) -> List[Dict[str, Any]]:
+        """List all roundups for a channel."""
+        index_key = f"news:{guild_id}:{channel_id}:roundup:_index"
+        slugs = await self.redis.smembers(index_key)
+        results = []
+        for slug in sorted(slugs):
+            config = await self.get_roundup_config(guild_id, channel_id, slug)
+            if config:
+                articles_key = f"news:{guild_id}:{channel_id}:roundup:{slug}:articles"
+                config["article_count"] = await self.redis.llen(articles_key)
+                results.append(config)
+        return results
+
+    async def add_roundup_article(self, guild_id: str, channel_id: str, name_normalized: str, article: Dict[str, Any]) -> int:
+        """Add an article to a roundup. Returns new length. Deduplicates by URL and caps at 100."""
+        articles_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:articles"
+        url = article.get("url") or article.get("link", "")
+        if url:
+            existing = await self.redis.lrange(articles_key, 0, -1)
+            for item in existing:
+                try:
+                    stored = json.loads(item)
+                    if stored.get("url") == url:
+                        return await self.redis.llen(articles_key)
+                except json.JSONDecodeError:
+                    pass
+        entry = json.dumps({
+            "title": article.get("title", ""),
+            "url": url,
+            "collected_at": datetime.utcnow().isoformat() + "Z",
+        })
+        await self.redis.lpush(articles_key, entry)
+        await self.redis.ltrim(articles_key, 0, 99)
+        return await self.redis.llen(articles_key)
+
+    async def get_roundup_articles(self, guild_id: str, channel_id: str, name_normalized: str, page: int = 1, page_size: int = 20):
+        """Get paginated articles for a roundup. Returns (articles, total)."""
+        articles_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:articles"
+        total = await self.redis.llen(articles_key)
+        start = (page - 1) * page_size
+        end = start + page_size - 1
+        raw = await self.redis.lrange(articles_key, start, end)
+        articles = []
+        for item in raw:
+            try:
+                articles.append(json.loads(item))
+            except json.JSONDecodeError:
+                pass
+        return articles, total
+
+    async def clear_roundup_articles(self, guild_id: str, channel_id: str, name_normalized: str) -> int:
+        """Clear all articles from a roundup. Returns count cleared."""
+        articles_key = f"news:{guild_id}:{channel_id}:roundup:{name_normalized}:articles"
+        count = await self.redis.llen(articles_key)
+        await self.redis.delete(articles_key)
+        return count
+
+    async def get_all_roundups_for_guild(self, guild_id: str) -> List[Dict[str, Any]]:
+        """Get all roundup configs across all channels for a guild. Used by the feed collector."""
+        pattern = f"news:{guild_id}:*:roundup:_index"
+        roundups = []
+        cursor = 0
+        while True:
+            cursor, keys = await self.redis.scan(cursor, match=pattern, count=100)
+            for key in keys:
+                parts = key.split(":")
+                # key format: news:{guild_id}:{channel_id}:roundup:_index
+                if len(parts) >= 5:
+                    channel_id = parts[2]
+                    slugs = await self.redis.smembers(key)
+                    for slug in slugs:
+                        config = await self.get_roundup_config(guild_id, channel_id, slug)
+                        if config:
+                            roundups.append(config)
+            if cursor == 0:
+                break
+        return roundups

--- a/bot/app/tasks/rss_feed_poster.py
+++ b/bot/app/tasks/rss_feed_poster.py
@@ -184,6 +184,36 @@ def extract_article_data(entry, feed, feed_name: str) -> Dict[str, Any]:
     }
 
 
+def _roundup_keyword_match(article_data: Dict[str, Any], match_query: str) -> bool:
+    """Check if any keyword from match_query appears in article title or description."""
+    title = (article_data.get("title") or "").lower()
+    description = (article_data.get("description") or "").lower()
+    text = f"{title} {description}"
+    terms = [t.strip().lower() for t in match_query.replace(",", " ").split() if t.strip()]
+    return any(term in text for term in terms)
+
+
+async def _roundup_llm_confirm(article_data: Dict[str, Any], match_query: str) -> bool:
+    """Use LLM to confirm if an article matches the roundup query."""
+    try:
+        from bot.api.openai.chat_completions_client import ChatCompletionsClient
+        client = ChatCompletionsClient.factory("gpt-4o-mini")
+        messages = [
+            {"role": "system", "content": "You are a classifier. Answer only 'yes' or 'no'."},
+            {"role": "user", "content": (
+                f'Does this article match the topic "{match_query}"?\n'
+                f'Article title: "{article_data.get("title", "")}"\n'
+                f'Article description: "{article_data.get("description", "")}"\n'
+                f'Answer only "yes" or "no".'
+            )},
+        ]
+        response = await client.chat(messages)
+        return response.strip().lower().startswith("yes")
+    except Exception as e:
+        logger.error("Roundup LLM confirmation failed: %s", e)
+        return False
+
+
 async def post_direct_items(
     to_post: Dict[int, List[Dict[str, Any]]],
     token: str
@@ -480,6 +510,32 @@ async def collect_rss_updates() -> None:
                                                 feed_name
                                             )
                                             logger.info(f"Breaking news match: '{matched_topic}' in {feed_name}")
+
+                        # Check for roundup matches
+                        try:
+                            roundups = await store.get_all_roundups_for_guild(guild_id_str)
+                            channel_roundups = [r for r in roundups if str(r.get("channel_id")) == str(channel_id)]
+                            if channel_roundups:
+                                for entry_item in new_entries:
+                                    art = extract_article_data(entry_item, feed, feed_name)
+                                    if not art.get("title"):
+                                        continue
+                                    for roundup_cfg in channel_roundups:
+                                        if _roundup_keyword_match(art, roundup_cfg["match_query"]):
+                                            if await _roundup_llm_confirm(art, roundup_cfg["match_query"]):
+                                                await store.add_roundup_article(
+                                                    guild_id_str,
+                                                    str(channel_id),
+                                                    roundup_cfg["name_normalized"],
+                                                    art,
+                                                )
+                                                logger.info(
+                                                    "Roundup '%s': collected article '%s'",
+                                                    roundup_cfg["name"],
+                                                    art.get("title", "")[:60],
+                                                )
+                        except Exception as e:
+                            logger.error("Roundup matching failed for guild %s: %s", guild_id_str, e)
 
                         # Route based on post_mode
                         if post_mode == "direct":


### PR DESCRIPTION
## Summary
Closes #26

- Adds `/news roundup` command subgroup with 5 commands: `add`, `list`, `show`, `clear`, `delete`
- Users create named roundups with a search query (e.g., `/news roundup add "New Releases" "new music releases"`)
- RSS feed collector matches new articles against roundup queries using keyword pre-filter + GPT-4o-mini LLM confirmation
- Matched articles stored in Redis (max 100 per roundup, FIFO, URL-deduplicated) and viewable with paginated `/news roundup show`

## Changes
- **`bot/app/redis/rss_store.py`** — 9 new `RSSRedisStore` methods for roundup CRUD, article storage, and guild-wide lookup
- **`bot/app/commands/news/news.py`** — `roundup` subgroup under `/news` with 5 slash commands + name normalization helper
- **`bot/app/tasks/rss_feed_poster.py`** — Keyword pre-filter + LLM confirmation helpers, integration block in `collect_rss_updates()` after breaking news matching

## Test plan
- [ ] `/news roundup add "AI News" "artificial intelligence"` creates roundup
- [ ] Duplicate name in same channel is rejected
- [ ] `/news roundup list` shows roundups with article counts
- [ ] Feed collector matches articles via keyword + LLM and stores them
- [ ] `/news roundup show` displays paginated articles
- [ ] `/news roundup clear` clears articles but keeps config
- [ ] `/news roundup delete` removes roundup and articles entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)