### PR TITLE
feat: add GPT Image 2 model across all image generation features

### DIFF
--- a/bot/app/commands/image/image.py
+++ b/bot/app/commands/image/image.py
@@ -69,6 +69,7 @@ class ImageCog(commands.Cog):
         self.bot = bot
         # Initialize multiple OpenAI clients for different models
         self.openai_clients = {
+            "gpt-image-2": ImageGenerationClient.factory(model="gpt-image-2-2026-04-21"),
             "chatgpt-image-latest": ImageGenerationClient.factory(model="chatgpt-image-latest"),
             "gpt-image-1.5": ImageGenerationClient.factory(model="gpt-image-1.5"),
             "gpt-image-1": ImageGenerationClient.factory(model="gpt-image-1"),
@@ -614,6 +615,7 @@ class ImageCog(commands.Cog):
     )
     @app_commands.choices(
         model=[
+            app_commands.Choice(name="GPT Image 2 (Latest)", value="gpt-image-2"),
             app_commands.Choice(name="Google Gemini 2.5 Flash", value="gemini"),
             app_commands.Choice(name="Google Gemini 3 Pro", value="gemini-3-pro-image-preview"),
             app_commands.Choice(name="Nano Banana 2 (gemini-3.1-flash-image-preview)", value="gemini-3.1-flash-image-preview"),

--- a/bot/app/commands/image/image_json.py
+++ b/bot/app/commands/image/image_json.py
@@ -27,7 +27,11 @@ logger = get_logger()
 class ImageJsonCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.openai_generation_client = ImageGenerationClient.factory()
+        self.openai_clients = {
+            "openai": ImageGenerationClient.factory(),
+            "gpt-image-2": ImageGenerationClient.factory(model="gpt-image-2-2026-04-21"),
+        }
+        self.openai_generation_client = self.openai_clients["openai"]
         self.openai_edit_client = ImageEditClient.factory()
 
         # Initialize Gemini clients (will only work if GOOGLE_API_KEY is set)
@@ -76,6 +80,9 @@ class ImageJsonCog(commands.Cog):
         if model == "gemini":
             generation_client = self.gemini_generation_client
             edit_client = self.gemini_edit_client
+        elif model in self.openai_clients:
+            generation_client = self.openai_clients[model]
+            edit_client = self.openai_edit_client
         else:
             generation_client = self.openai_generation_client
             edit_client = self.openai_edit_client
@@ -252,7 +259,8 @@ class ImageJsonCog(commands.Cog):
     )
     @app_commands.choices(
         model=[
-            app_commands.Choice(name="OpenAI (GPT Image)", value="openai"),
+            app_commands.Choice(name="GPT Image 2 (Latest)", value="gpt-image-2"),
+            app_commands.Choice(name="OpenAI (GPT Image 1)", value="openai"),
             app_commands.Choice(name="Google Gemini 2.5 Flash", value="gemini"),
         ]
     )

--- a/bot/domain/agent/agent_tools.py
+++ b/bot/domain/agent/agent_tools.py
@@ -76,6 +76,12 @@ TOOL_SCHEMAS: Dict[str, dict] = {
                         "description": "Image dimensions. Default square.",
                         "default": "1024x1024",
                     },
+                    "model": {
+                        "type": "string",
+                        "enum": ["gemini", "gpt-image-2", "gpt-image-1"],
+                        "description": "Model to use for generation. Default gemini.",
+                        "default": "gemini",
+                    },
                 },
                 "required": ["prompt"],
             },
@@ -129,12 +135,14 @@ TOOL_SCHEMAS: Dict[str, dict] = {
                         "enum": [
                             "gemini-2.5-flash",
                             "gemini-3-pro",
+                            "gpt-image-2",
                             "gpt-image-1",
                         ],
                         "description": (
                             "Image model to use. "
                             "gemini-2.5-flash (default, fast and cheap), "
                             "gemini-3-pro (higher quality), "
+                            "gpt-image-2 (OpenAI latest), "
                             "gpt-image-1 (OpenAI)."
                         ),
                         "default": "gemini-2.5-flash",
@@ -287,29 +295,46 @@ async def execute_generate_image(
     """Execute the generate_image tool. Returns status message; image is sent to channel."""
     prompt = arguments.get("prompt", "")
     size = arguments.get("size", "1024x1024")
+    model_pref = arguments.get("model", "gemini")
 
     if not prompt:
         return "No prompt provided for image generation."
 
-    # Try Gemini first, fall back to OpenAI
     image_bytes: Optional[bytes] = None
     error_msg = ""
     model_used = ""
 
-    try:
-        client = GeminiImageGenerationClient.factory()
-        image_bytes, error_msg = await client.generate_image(prompt, size=size)
-        model_used = "Gemini"
-    except EnvironmentError:
-        pass  # GOOGLE_API_KEY not set
-
-    if image_bytes is None:
+    # Route to the requested model
+    if model_pref == "gpt-image-2":
+        try:
+            client = ImageGenerationClient.factory(model="gpt-image-2-2026-04-21")
+            image_bytes, error_msg = await client.generate_image(prompt, size=size)
+            model_used = "GPT Image 2"
+        except EnvironmentError:
+            return "OpenAI image generation is not available (no API key configured)."
+    elif model_pref == "gpt-image-1":
         try:
             client = ImageGenerationClient.factory()
             image_bytes, error_msg = await client.generate_image(prompt, size=size)
-            model_used = "OpenAI"
+            model_used = "GPT Image 1"
         except EnvironmentError:
-            return "Image generation is not available (no API keys configured)."
+            return "OpenAI image generation is not available (no API key configured)."
+    else:
+        # Default: try Gemini first, fall back to OpenAI
+        try:
+            client = GeminiImageGenerationClient.factory()
+            image_bytes, error_msg = await client.generate_image(prompt, size=size)
+            model_used = "Gemini"
+        except EnvironmentError:
+            pass  # GOOGLE_API_KEY not set
+
+        if image_bytes is None:
+            try:
+                client = ImageGenerationClient.factory()
+                image_bytes, error_msg = await client.generate_image(prompt, size=size)
+                model_used = "OpenAI"
+            except EnvironmentError:
+                return "Image generation is not available (no API keys configured)."
 
     if image_bytes is None:
         return f"Image generation failed: {error_msg}"
@@ -339,6 +364,7 @@ async def execute_roll_dice(arguments: Dict[str, Any]) -> str:
 IMAGE_EDIT_MODELS = {
     "gemini-2.5-flash": "gemini-2.5-flash-image",
     "gemini-3-pro": "gemini-3-pro-image-preview",
+    "gpt-image-2": "gpt-image-2-2026-04-21",
     "gpt-image-1": "gpt-image-1",
 }
 


### PR DESCRIPTION
## Summary
Added `gpt-image-2-2026-04-21` (the latest GPT image model) as an option in all image generation features.

## Changes

### /image command (`bot/app/commands/image/image.py`)
- New client in `openai_clients` dict: `"gpt-image-2"` → `gpt-image-2-2026-04-21`
- New Discord choice: "GPT Image 2 (Latest)" at the top of the model list

### /image-json command (`bot/app/commands/image/image_json.py`)
- New client in `openai_clients` dict: `"gpt-image-2"` → `gpt-image-2-2026-04-21`
- Updated model selection logic to route `gpt-image-2` to the correct client
- New Discord choice: "GPT Image 2 (Latest)"

### Agent tools (`bot/domain/agent/agent_tools.py`)
- `generate_image` tool: added `model` parameter with `gemini`, `gpt-image-2`, `gpt-image-1` options
- `edit_image` tool: added `gpt-image-2` to model enum and `IMAGE_EDIT_MODELS` mapping

## Test plan
- [ ] `/image prompt:"a cat" model:GPT Image 2 (Latest)` → generates with gpt-image-2
- [ ] `/image-json` with GPT Image 2 model → generates correctly
- [ ] Agent: ask it to generate an image with gpt-image-2 model
- [ ] Existing models (Gemini, GPT Image 1, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)