### PR TITLE
Auto-deploy on push to main

### DIFF
--- a/scripts/README_autodeploy.md
+++ b/scripts/README_autodeploy.md
@@ -1,0 +1,41 @@
+# Auto-deploy on push to `main`
+
+A systemd timer on the Pi polls `origin/main` every 2 minutes. If new commits
+are present, it pulls and runs `docker compose up -d --build`. The effect is
+that merging a PR (e.g. from the GitHub mobile app) deploys the change a
+couple of minutes later with no SSH from the laptop.
+
+## One-time install on the Pi
+
+```bash
+ssh dad@192.168.1.182
+cd /home/dad/cunningbot
+git pull
+
+sudo cp scripts/cunningbot-autodeploy.service /etc/systemd/system/
+sudo cp scripts/cunningbot-autodeploy.timer   /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now cunningbot-autodeploy.timer
+```
+
+## Verifying
+
+```bash
+systemctl list-timers cunningbot-autodeploy.timer
+journalctl -u cunningbot-autodeploy.service -n 50 --no-pager
+```
+
+A no-op run prints nothing. A real deploy logs `Deploying <old> -> <new>` then
+`Deploy complete`.
+
+## Manual trigger
+
+```bash
+sudo systemctl start cunningbot-autodeploy.service
+```
+
+## Disable
+
+```bash
+sudo systemctl disable --now cunningbot-autodeploy.timer
+```

--- a/scripts/auto_deploy.sh
+++ b/scripts/auto_deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pulls and rebuilds cunningbot when origin/main has new commits.
+# Intended to be run on a timer (see scripts/cunningbot-autodeploy.{service,timer}).
+set -euo pipefail
+
+REPO_DIR="${CUNNINGBOT_REPO_DIR:-/home/dad/cunningbot}"
+BRANCH="${CUNNINGBOT_BRANCH:-main}"
+
+cd "$REPO_DIR"
+
+git fetch --quiet origin "$BRANCH"
+
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse "origin/$BRANCH")
+
+if [ "$local_sha" = "$remote_sha" ]; then
+    exit 0
+fi
+
+echo "Deploying $local_sha -> $remote_sha"
+git pull --ff-only origin "$BRANCH"
+docker compose up -d --build
+echo "Deploy complete"

--- a/scripts/cunningbot-autodeploy.service
+++ b/scripts/cunningbot-autodeploy.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pull and rebuild cunningbot when origin/main updates
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=dad
+WorkingDirectory=/home/dad/cunningbot
+ExecStart=/home/dad/cunningbot/scripts/auto_deploy.sh

--- a/scripts/cunningbot-autodeploy.timer
+++ b/scripts/cunningbot-autodeploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run cunningbot auto-deploy check every 2 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Unit=cunningbot-autodeploy.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Adds `scripts/auto_deploy.sh`: polls `origin/main`, pulls + `docker compose up -d --build` when new commits land.
- Adds a systemd service + timer that runs the script every 2 minutes on the Pi.
- Adds `scripts/README_autodeploy.md` with the one-time install steps.

After this lands, merging a PR (e.g. from the GitHub mobile app) will deploy automatically within ~2 minutes — no SSH required.

## Test plan
- [ ] Merge this PR
- [ ] SSH to Pi once and run the install steps in `scripts/README_autodeploy.md`
- [ ] `systemctl list-timers cunningbot-autodeploy.timer` shows next run
- [ ] `journalctl -u cunningbot-autodeploy.service -n 50` is clean for no-op runs
- [ ] Push a trivial commit to `main` from mobile and confirm bot rebuilds + reconnects within ~2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)